### PR TITLE
Changed how you allocate Ram in the launcher from percent to now mb and fix

### DIFF
--- a/src-tauri/src/app/app_data.rs
+++ b/src-tauri/src/app/app_data.rs
@@ -22,7 +22,7 @@ use std::{path::Path, collections::HashMap};
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use tokio::fs;
-use crate::{auth::ClientAccount, minecraft::auth::MinecraftAccount};
+use crate::{auth::ClientAccount, minecraft::auth::MinecraftAccount, utils::total_system_memory_in_mb};
 
 fn default_concurrent_downloads() -> i32 {
     10
@@ -36,10 +36,12 @@ pub(crate) struct LauncherOptions {
     pub custom_data_path: String,
     #[serde(rename = "showNightlyBuilds")]
     pub show_nightly_builds: bool,
-    #[serde(rename = "memoryPercentage")]
-    pub memory_percentage: i32,
     #[serde(rename = "customJavaPath", default)]
     pub custom_java_path: String,
+    #[serde(rename = "systemMemory")]
+    pub system_memory: i64,
+    #[serde(rename = "allocatedMemory")]
+    pub allocated_memory: i64,
     #[serde(rename = "selectedBranch")]
     pub selected_branch: Option<String>,
     #[serde(rename = "selectedBuild")]
@@ -86,8 +88,9 @@ impl Default for LauncherOptions {
             keep_launcher_open: false,
             custom_data_path: String::new(),
             show_nightly_builds: false,
-            memory_percentage: 80, // 80% memory of computer allocated to game
             custom_java_path: String::new(),
+            system_memory: total_system_memory_in_mb(),
+            allocated_memory: total_system_memory_in_mb() / 2,
             selected_branch: None,
             selected_build: None,
             client_account: None,

--- a/src-tauri/src/app/gui.rs
+++ b/src-tauri/src/app/gui.rs
@@ -27,7 +27,6 @@ use uuid::Uuid;
 
 use crate::{auth::{ClientAccountAuthenticator, ClientAccount}, minecraft::{auth::{self, MinecraftAccount}, launcher::{LauncherData, LaunchingParameter}, prelauncher, progress::ProgressUpdate}, HTTP_CLIENT, LAUNCHER_DIRECTORY, LAUNCHER_VERSION};
 use crate::app::api::{Branches, Changelog, ContentDelivery, News};
-use crate::utils::percentage_of_total_memory;
 
 use super::{api::{ApiEndpoints, Build, LoaderMod, ModSource}, app_data::LauncherOptions};
 
@@ -299,7 +298,7 @@ async fn run_client(
     let xuid = Uuid::new_v4().to_string();
 
     let parameters = LaunchingParameter {
-        memory: percentage_of_total_memory(options.memory_percentage),
+        memory: options.allocated_memory,
         custom_data_path: if !options.custom_data_path.is_empty() { Some(options.custom_data_path) } else { None },
         custom_java_path: if !options.custom_java_path.is_empty() { Some(options.custom_java_path) } else { None },
         auth_player_name: account_name,
@@ -403,11 +402,6 @@ async fn logout(account_data: MinecraftAccount) -> Result<(), String> {
 }
 
 #[tauri::command]
-async fn mem_percentage(memory_percentage: i32) -> i64 {
-    percentage_of_total_memory(memory_percentage)
-}
-
-#[tauri::command]
 async fn fetch_news() -> Result<Vec<News>, String> {
     ContentDelivery::news()
         .await
@@ -505,7 +499,6 @@ pub fn gui_main() {
             fetch_news,
             fetch_changelog,
             clear_data,
-            mem_percentage,
             default_data_folder_path,
             terminate,
             get_launcher_version,

--- a/src-tauri/src/utils/sys.rs
+++ b/src-tauri/src/utils/sys.rs
@@ -24,10 +24,9 @@ use serde::Deserialize;
 use sysinfo::{RefreshKind, System, SystemExt};
 
 /// Get the total memory of the system in bytes
-pub fn percentage_of_total_memory(memory_percentage: i32) -> i64 {
+pub fn total_system_memory_in_mb() -> i64 {
     let sys = System::new_with_specifics(RefreshKind::new().with_memory());
-
-    ((sys.total_memory() / 1000000) as f64 * (memory_percentage as f64 / 100.0)) as i64
+    (sys.total_memory() / 1024 / 1024) as i64
 }
 
 pub const OS: OperatingSystem = if cfg!(target_os = "windows") {

--- a/src/lib/main/MainScreen.svelte
+++ b/src/lib/main/MainScreen.svelte
@@ -402,11 +402,11 @@
                 windowTitle="Select custom data directory"
             />
             <RangeSetting
-                title="Memory"
-                min={20}
-                max={100}
-                bind:value={options.memoryPercentage}
-                valueSuffix="%"
+                title="Allocated Memory"
+                min={1}
+                max={options.systemMemory}
+                bind:value={options.allocatedMemory}
+                valueSuffix="MB"
                 step={1}
             />
 


### PR DESCRIPTION
I changed the launcher to now use mb to allocate and not do some fancy stuff and there was an small conversion bug right here: `((sys.total_memory() / **1000000**) as f64 * (memory_percentage as f64 / 100.0)) as i64`.
![2024-11-30-091424_hyprshot](https://github.com/user-attachments/assets/45016f3b-060d-4bf3-80b7-76a76504632c)
![2024-11-30-091339_hyprshot](https://github.com/user-attachments/assets/68b65ec0-e7a9-4371-a63e-9b6a466ede06)
This is my first pull request so im verry sorry about any errors I made.